### PR TITLE
fix missing thumbnails for some files

### DIFF
--- a/stlthumbnail.json
+++ b/stlthumbnail.json
@@ -2,7 +2,10 @@
   "CacheThumbnail": true,
   "KPlugin": {
       "MimeTypes": [
-          "model/stl"
+          "model/stl",
+          "application/sla",
+          "model/x.stl-ascii",
+          "model/x.stl-binary"
       ],
       "Name": "STL documents"
   }


### PR DESCRIPTION
On kubuntu 24.04 some files were not pre-generating. This should add their mimetypes and then autogenerate the missing thumbnails.